### PR TITLE
add package build CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v8
         with:
           python-version: "3.12"
       - run: uv sync --frozen --extra dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.12"
       - run: uv sync --frozen --extra dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+      - run: uv sync --frozen --extra dev
+      - run: uv run python -m compileall -q src tests
+      - run: uv build
+


### PR DESCRIPTION
## Summary

- add a least-privilege CI workflow for the repository's actual toolchain
- install dependencies from the committed lockfile where one exists
- run the strongest repeatable build, test, lint, or syntax checks supported by the project
- include baseline repairs required for those checks when applicable

## Why

GitHub Actions was enabled, but this repository had no code-validation workflow. Changes could reach the default branch or deployment without an automated build gate.

## Validation

- workflow YAML parsed successfully
- whitespace validation passed
- project checks were run locally where the toolchain is available
- this PR's GitHub Actions run provides the clean hosted-runner verification
